### PR TITLE
dao类里面有两个地方没有给表名称两侧添加`号

### DIFF
--- a/entity.php
+++ b/entity.php
@@ -553,14 +553,14 @@ class dao
 
     public function count()
     {/*{{{*/
-        $sql = 'select count(*) as count from '.$this->table_name;
+        $sql = 'select count(*) as count from `'.$this->table_name.'`';
 
         return db_query_value('count', $sql, [], $this->db_config_key);
     }/*}}}*/
 
     protected function count_by_condition($condition, array $binds = [])
     {/*{{{*/
-        $sql = 'select count(*) as count from '.$this->table_name.' where '.$condition;
+        $sql = 'select count(*) as count from `'.$this->table_name.'` where '.$condition;
 
         return db_query_value('count', $sql, $binds, $this->db_config_key);
     }/*}}}*/


### PR DESCRIPTION
当描述文件描述的实体与MySQL关键字重名时，查询失败。